### PR TITLE
various fixes, now works with shim-eth-vlan and normal DIF

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,13 +4,9 @@
 # Written by: Francesco Salvestrini <f DOT salvestrini AT nextworks DOT it>
 #
 
-AC_INIT([RINA Traffic Generator],
-        m4_esyscmd([build-aux/git-version-gen .tarball-version]),
-        [dimitri.staessens@intec.ugent.be],
-        [rina-tgen],
-        [http://github.com/irati/traffic-generator])
+AC_INIT([RINA Traffic Generator],[m4_esyscmd(build-aux/git-version-gen .tarball-version)],[dimitri.staessens@intec.ugent.be],[rina-tgen],[http://github.com/irati/traffic-generator])
 
-AC_PREREQ([2.68])
+AC_PREREQ([2.69])
 
 AC_CONFIG_HEADERS([src/config.h])
 AC_CONFIG_SRCDIR([src/main.cc])

--- a/src/client.cc
+++ b/src/client.cc
@@ -51,20 +51,20 @@ void Client::run()
 
 Flow * Client::createFlow()
 {
-        Flow * flow = 0;
+	Flow * flow = 0;
         AllocateFlowRequestResultEvent * afrrevent;
         FlowSpecification qosspec;
         IPCEvent * event;
         unsigned int seqnum;
 
-        if (!std::string("reliable").compare(qoscube))
-                qosspec.maxAllowableGap = 0;
-        else if (!std::string("unreliable").compare(qoscube))
+	if (!std::string("reliable").compare(qoscube))
+		qosspec.maxAllowableGap = 0;
+        if (!std::string("unreliable").compare(qoscube))
                 qosspec.maxAllowableGap = 1;
 	else
 		throw IPCException("not a valid qoscube");
 
-        if (difName != string()) {
+	if (difName != string()) {
                 seqnum = ipcManager->requestFlowAllocationInDIF(
                                 ApplicationProcessNamingInformation(appName, appInstance),
                                 ApplicationProcessNamingInformation(serverName, serverInstance),
@@ -102,9 +102,11 @@ Flow * Client::createFlow()
 
 void Client::setup(Flow * flow)
 {
-        char initData[sizeof(count) + sizeof(duration) + sizeof(sduSize)];
+	//TODO: clean up this fix, padding of 32 bytes added to avoid runt frames
+	//when using the shim DIF over Ethernet directly
+	char initData[sizeof(count) + sizeof(duration) + sizeof(sduSize) + 32];
 
-        unsigned long long ncount = htobe64(count);
+	unsigned long long ncount = htobe64(count);
         unsigned int ndur = htobe32(duration);
         unsigned int nsize = htobe32(sduSize);
 
@@ -113,11 +115,11 @@ void Client::setup(Flow * flow)
         memcpy(&initData[sizeof(ncount) + sizeof(ndur)], &nsize, sizeof(nsize));
 
         flow->writeSDU(initData,
-                        sizeof(count) + sizeof(duration) + sizeof(sduSize));
+                        sizeof(count) + sizeof(duration) + sizeof(sduSize)+32);
 
-        char response[51];
-        response[50] = '\0';
-        flow->readSDU(response, 50);
+        char response[128];
+        response[127] = '\0';
+        flow->readSDU(response, 127);
 
         LOG_INFO("starting test");
 }
@@ -132,7 +134,6 @@ void Client::constantBitRate(Flow * flow)
         double byteMilliRate;
         double intervalTime = 0;
         char toSend[sduSize];
-
         if (rate) {
                 byteMilliRate = rate / 8.0; /*kB/s */
                 intervalTime = sduSize / byteMilliRate; /* ms */
@@ -258,7 +259,7 @@ void Client::sleepUntil(const struct timespec &deadline)
 	struct timespec diff;
         clock_gettime(CLOCK_REALTIME, &now);
 	subtime(&deadline,&now,&diff);
-	nanosleep (&diff, NULL);	        
+	nanosleep (&diff, NULL);
 }
 
 void Client::destroyFlow(Flow * flow)

--- a/src/client.cc
+++ b/src/client.cc
@@ -76,6 +76,7 @@ Flow * Client::createFlow()
                                 ApplicationProcessNamingInformation(serverName, serverInstance),
                                 qosspec);
         }
+
 	for (;;) {
                 event = ipcEventProducer->eventWait();
                 if (event && event->eventType == ALLOCATE_FLOW_REQUEST_RESULT_EVENT

--- a/src/client.cc
+++ b/src/client.cc
@@ -51,20 +51,20 @@ void Client::run()
 
 Flow * Client::createFlow()
 {
-	Flow * flow = 0;
+        Flow * flow = 0;
         AllocateFlowRequestResultEvent * afrrevent;
         FlowSpecification qosspec;
         IPCEvent * event;
         unsigned int seqnum;
 
-	if (!std::string("reliable").compare(qoscube))
-		qosspec.maxAllowableGap = 0;
+        if (!std::string("reliable").compare(qoscube))
+                qosspec.maxAllowableGap = 0;
         if (!std::string("unreliable").compare(qoscube))
                 qosspec.maxAllowableGap = 1;
-	else
+        else
 		throw IPCException("not a valid qoscube");
 
-	if (difName != string()) {
+        if (difName != string()) {
                 seqnum = ipcManager->requestFlowAllocationInDIF(
                                 ApplicationProcessNamingInformation(appName, appInstance),
                                 ApplicationProcessNamingInformation(serverName, serverInstance),
@@ -102,11 +102,11 @@ Flow * Client::createFlow()
 
 void Client::setup(Flow * flow)
 {
-	//TODO: clean up this fix, padding of 32 bytes added to avoid runt frames
-	//when using the shim DIF over Ethernet directly
-	char initData[sizeof(count) + sizeof(duration) + sizeof(sduSize) + 32];
+        //TODO: clean up this fix, padding of 32 bytes added to avoid runt frames
+        //when using the shim DIF over Ethernet directly
+        char initData[sizeof(count) + sizeof(duration) + sizeof(sduSize) + 32];
 
-	unsigned long long ncount = htobe64(count);
+        unsigned long long ncount = htobe64(count);
         unsigned int ndur = htobe32(duration);
         unsigned int nsize = htobe32(sduSize);
 

--- a/src/client.cc
+++ b/src/client.cc
@@ -57,14 +57,14 @@ Flow * Client::createFlow()
         IPCEvent * event;
         unsigned int seqnum;
 
-        if (!std::string("reliable").compare(qoscube))
+	if (!std::string("reliable").compare(qoscube))
                 qosspec.maxAllowableGap = 0;
-        if (!std::string("unreliable").compare(qoscube))
-                qosspec.maxAllowableGap = 1;
-        else
+	else if (!std::string("unreliable").compare(qoscube))
+		qosspec.maxAllowableGap = -1;
+	else
 		throw IPCException("not a valid qoscube");
 
-        if (difName != string()) {
+	if (difName != string()) {
                 seqnum = ipcManager->requestFlowAllocationInDIF(
                                 ApplicationProcessNamingInformation(appName, appInstance),
                                 ApplicationProcessNamingInformation(serverName, serverInstance),
@@ -76,8 +76,7 @@ Flow * Client::createFlow()
                                 ApplicationProcessNamingInformation(serverName, serverInstance),
                                 qosspec);
         }
-
-        for (;;) {
+	for (;;) {
                 event = ipcEventProducer->eventWait();
                 if (event && event->eventType == ALLOCATE_FLOW_REQUEST_RESULT_EVENT
                                 && event->sequenceNumber == seqnum) {
@@ -86,7 +85,7 @@ Flow * Client::createFlow()
                 LOG_DBG("Client got new event %d", event->eventType);
         }
 
-        afrrevent = dynamic_cast<AllocateFlowRequestResultEvent*>(event);
+	afrrevent = dynamic_cast<AllocateFlowRequestResultEvent*>(event);
 
         flow = ipcManager->commitPendingFlow(afrrevent->sequenceNumber,
                         afrrevent->portId,

--- a/src/client.cc
+++ b/src/client.cc
@@ -57,14 +57,14 @@ Flow * Client::createFlow()
         IPCEvent * event;
         unsigned int seqnum;
 
-	if (!std::string("reliable").compare(qoscube))
+        if (!std::string("reliable").compare(qoscube))
                 qosspec.maxAllowableGap = 0;
-	else if (!std::string("unreliable").compare(qoscube))
-		qosspec.maxAllowableGap = -1;
-	else
-		throw IPCException("not a valid qoscube");
+        else if (!std::string("unreliable").compare(qoscube))
+                qosspec.maxAllowableGap = -1;
+        else
+                throw IPCException("not a valid qoscube");
 
-	if (difName != string()) {
+        if (difName != string()) {
                 seqnum = ipcManager->requestFlowAllocationInDIF(
                                 ApplicationProcessNamingInformation(appName, appInstance),
                                 ApplicationProcessNamingInformation(serverName, serverInstance),
@@ -85,7 +85,7 @@ Flow * Client::createFlow()
                 LOG_DBG("Client got new event %d", event->eventType);
         }
 
-	afrrevent = dynamic_cast<AllocateFlowRequestResultEvent*>(event);
+        afrrevent = dynamic_cast<AllocateFlowRequestResultEvent*>(event);
 
         flow = ipcManager->commitPendingFlow(afrrevent->sequenceNumber,
                         afrrevent->portId,

--- a/src/client.h
+++ b/src/client.h
@@ -51,29 +51,29 @@ public:
         void run();
 
 protected:
-       rina::Flow * createFlow();
-       void setup(rina::Flow * flow);
-       void constantBitRate(rina::Flow * flow);
-       void poissonDistribution(rina::Flow * flow);
-       void receiveServerStats(rina::Flow * flow);
-       void destroyFlow(rina::Flow * flow);
+        rina::Flow * createFlow();
+        void setup(rina::Flow * flow);
+        void constantBitRate(rina::Flow * flow);
+        void poissonDistribution(rina::Flow * flow);
+        void receiveServerStats(rina::Flow * flow);
+        void destroyFlow(rina::Flow * flow);
 
 private:
-       std::string difName;
-       std::string serverName;
-       std::string serverInstance;
-       bool registerClient;
-       std::string distributionType;
-       unsigned int sduSize;
-       unsigned long long count;
-       unsigned int duration;
-       unsigned int rate;
-       std::string qoscube;
-       bool busy;
-       double poissonmean;
+        std::string difName;
+        std::string serverName;
+        std::string serverInstance;
+        bool registerClient;
+        std::string distributionType;
+        unsigned int sduSize;
+        unsigned long long count;
+        unsigned int duration;
+        unsigned int rate;
+        std::string qoscube;
+        bool busy;
+        double poissonmean;
 
-       void busyWaitUntil (const struct timespec &deadline);
-       void sleepUntil(const struct timespec &deadline);
-       unsigned int secondsElapsed(struct timespec &start);
+        void busyWaitUntil (const struct timespec &deadline);
+        void sleepUntil(const struct timespec &deadline);
+        unsigned int secondsElapsed(struct timespec &start);
 };
 #endif//CLIENT_HPP

--- a/src/client.h
+++ b/src/client.h
@@ -16,21 +16,21 @@
 #include "application.h"
 
 class Client: public Application {
-        public:
-                Client(const std::string& difName_,
-                                const std::string& apn,
-                                const std::string& api,
-                                const std::string& serverApn,
-                                const std::string& serverApi,
-                                bool registration,
-                                const std::string& distributionType_,
-                                unsigned int size_,
-                                unsigned long long count_,
-                                unsigned int duration_,
-                                unsigned int rate_,
-		                const std::string& qoscube_,
-		                bool busy_,
-		                double poissonmean_) :
+public:
+        Client(const std::string& difName_,
+               const std::string& apn,
+               const std::string& api,
+               const std::string& serverApn,
+               const std::string& serverApi,
+               bool registration,
+               const std::string& distributionType_,
+               unsigned int size_,
+               unsigned long long count_,
+               unsigned int duration_,
+               unsigned int rate_,
+               const std::string& qoscube_,
+	       bool busy_,
+	       double poissonmean_) :
                         Application(difName_, apn, api),
                         difName(difName_),
                         serverName(serverApn),
@@ -48,32 +48,32 @@ class Client: public Application {
                                         throw rina::IPCException(
 					"not a valid count and duration combination!");
                         }
+        void run();
 
-                void run();
-        protected:
-                rina::Flow * createFlow();
-                void setup(rina::Flow * flow);
-                void constantBitRate(rina::Flow * flow);
-                void poissonDistribution(rina::Flow * flow);
-                void receiveServerStats(rina::Flow * flow);
-                void destroyFlow(rina::Flow * flow);
+protected:
+       rina::Flow * createFlow();
+       void setup(rina::Flow * flow);
+       void constantBitRate(rina::Flow * flow);
+       void poissonDistribution(rina::Flow * flow);
+       void receiveServerStats(rina::Flow * flow);
+       void destroyFlow(rina::Flow * flow);
 
-        private:
-                std::string difName;
-                std::string serverName;
-                std::string serverInstance;
-                bool registerClient;
-                std::string distributionType;
-                unsigned int sduSize;
-                unsigned long long count;
-                unsigned int duration;
-                unsigned int rate;
-                std::string qoscube;
-                bool busy;
-		double poissonmean;
+private:
+       std::string difName;
+       std::string serverName;
+       std::string serverInstance;
+       bool registerClient;
+       std::string distributionType;
+       unsigned int sduSize;
+       unsigned long long count;
+       unsigned int duration;
+       unsigned int rate;
+       std::string qoscube;
+       bool busy;
+       double poissonmean;
 
-                void busyWaitUntil (const struct timespec &deadline);
-		void sleepUntil(const struct timespec &deadline);
-                unsigned int secondsElapsed(struct timespec &start);
+       void busyWaitUntil (const struct timespec &deadline);
+       void sleepUntil(const struct timespec &deadline);
+       unsigned int secondsElapsed(struct timespec &start);
 };
 #endif//CLIENT_HPP

--- a/src/main.cc
+++ b/src/main.cc
@@ -22,25 +22,25 @@
 #include "client.h"
 #include "server.h"
 
-static bool listen;
-static bool registration;
-static bool busy;
-static unsigned long long count;
-static unsigned int size;
-static unsigned int rate;
-static unsigned int duration;
-static unsigned int interval;
-static std::string serverApn;
-static std::string serverApi;
-static std::string clientApn;
-static std::string clientApi;
-static std::string difName;
-static std::string distributionType;
-static std::string qoscube;
-static double poissonmean;
-
-void parseArgs(int argc, char *argv[])
+int main(int argc, char * argv[])
 {
+        static bool listen;
+        static bool registration;
+        static bool busy;
+        static unsigned long long count;
+        static unsigned int size;
+        static unsigned int rate;
+        static unsigned int duration;
+        static unsigned int interval;
+        static std::string serverApn;
+        static std::string serverApi;
+        static std::string clientApn;
+        static std::string clientApi;
+        static std::string difName;
+        static std::string distributionType;
+        static std::string qoscube;
+        static double poissonmean;
+
         try {
                 TCLAP::CmdLine cmd("traffic-generator", ' ', PACKAGE_VERSION);
                 TCLAP::SwitchArg listenArg("l",
@@ -182,13 +182,6 @@ void parseArgs(int argc, char *argv[])
                                 e.argId().c_str());
                 exit(1);
         }
-
-}
-
-int main(int argc, char * argv[])
-{
-
-        parseArgs(argc, argv);
 
         try {
                 rina::initialize("INFO", "");

--- a/src/main.cc
+++ b/src/main.cc
@@ -206,7 +206,7 @@ int main(int argc, char * argv[])
 
                         c.run();
                 }
-        } catch (Exception& e) {
+        } catch (rina::Exception& e) {
                 LOG_ERR("%s", e.what());
                 return EXIT_FAILURE;
         }

--- a/src/server.cc
+++ b/src/server.cc
@@ -79,9 +79,9 @@ void Server::startReceive(Flow * flow)
         unsigned int       duration;
         unsigned int       sduSize;
 
-        char initData[sizeof(count) + sizeof(duration) + sizeof(sduSize)];
+        char initData[sizeof(count) + sizeof(duration) + sizeof(sduSize) + 32];
 
-        flow->readSDU(initData, sizeof(count) + sizeof(duration) + sizeof(sduSize));
+        flow->readSDU(initData, sizeof(count) + sizeof(duration) + sizeof(sduSize) + 32);
 
         memcpy(&count, initData, sizeof(count));
         memcpy(&duration, &initData[sizeof(count)], sizeof(duration));
@@ -90,7 +90,7 @@ void Server::startReceive(Flow * flow)
         duration = be32toh(duration);
         sduSize = be32toh(sduSize);
 
-        char response[] = "Go ahead!";
+        char response[] = "Go ahead!                                               ";
         struct timespec start;
         struct timespec end;
         struct timespec tmp;

--- a/src/server.h
+++ b/src/server.h
@@ -27,7 +27,7 @@ public:
                        Application(difName, appName, appInstance),
                        interval(interval_) {}
 
-	       void run();
+                void run();
 
 protected:
 

--- a/src/server.h
+++ b/src/server.h
@@ -19,22 +19,22 @@
 
 class Server: public Application
 {
-        public:
-                Server(const std::string& difName,
-                                const std::string& appName,
-                                const std::string& appInstance,
-                                unsigned int interval_) :
-                        Application(difName, appName, appInstance),
-                        interval(interval_) {}
+public:
+        Server(const std::string& difName,
+               const std::string& appName,
+               const std::string& appInstance,
+               unsigned int interval_) :
+                       Application(difName, appName, appInstance),
+                       interval(interval_) {}
 
-                void run();
+	       void run();
 
-        protected:
+protected:
 
-        private:
-                void startReceive(rina::Flow * flow);
-                static void timesUp(sigval_t val);
-                unsigned int interval;
+private:
+        void startReceive(rina::Flow * flow);
+        static void timesUp(sigval_t val);
+        unsigned int interval;
 };
 
 #endif


### PR DESCRIPTION
shim-eth-vlan had a runt frame issue when negotiating the parameters with the server
normal DIF now can run with --qoscube unreliable, full functionality when #527 in stack is resolved
