### PR TITLE
client.cc: fixed compilation errors

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -121,7 +121,8 @@ void client::single_cbr_test(unsigned int size,
 		        sleep_until(deadline);
                 seq++;
 		clock_gettime(CLOCK_REALTIME, &end);
-                if (duration && ts_diff_us(start, end)/MILLION >= duration)
+                if (duration &&
+                		(unsigned int)ts_diff_us(start, end)/MILLION >= duration)
                         stop = true;
                 if (!duration && count && seq >= count)
 		  stop = true;
@@ -179,7 +180,8 @@ void client::single_poisson_test(unsigned int size,
 		        sleep_until(next);
                 seq++;
                 clock_gettime(CLOCK_REALTIME, &end);
-                if (duration != 0 && ts_diff_us(start, end)/MILLION >= duration)
+                if (duration != 0 &&
+                		(unsigned int)ts_diff_us(start, end)/MILLION >= duration)
                         stop = 1;
                 if (count != 0 && seq >= count)
 		        stop = 1;

--- a/src/client.cc
+++ b/src/client.cc
@@ -122,7 +122,7 @@ void client::single_cbr_test(unsigned int size,
                 seq++;
 		clock_gettime(CLOCK_REALTIME, &end);
                 if (duration &&
-                		(unsigned int)ts_diff_us(start, end)/MILLION >= duration)
+                		ts_diff_us(start, end)/MILLION >= (long)duration)
                         stop = true;
                 if (!duration && count && seq >= count)
 		  stop = true;
@@ -181,7 +181,7 @@ void client::single_poisson_test(unsigned int size,
                 seq++;
                 clock_gettime(CLOCK_REALTIME, &end);
                 if (duration != 0 &&
-                		(unsigned int)ts_diff_us(start, end)/MILLION >= duration)
+                		ts_diff_us(start, end)/MILLION >= (long)duration)
                         stop = 1;
                 if (count != 0 && seq >= count)
 		        stop = 1;


### PR DESCRIPTION
Fixed two comparisons of long vs. unsigned int that were giving compilation errors (gcc 4.9.2)

Maintainers: @dstaesse 
