### PR TITLE
timeutils refactored to C

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@ rina_tgen_SOURCES  =				\
 	simple_ap.cc		simple_ap.h	\
 	server.cc		server.h	\
 	client.cc		client.h	\
-        timeutils.cc		timeutils.h	\
+        timeutils.c		timeutils.h	\
         main.cc
 
 rina_tgen_LDADD    = $(LIBRINA_LIBS)		\

--- a/src/client.cc
+++ b/src/client.cc
@@ -121,16 +121,15 @@ void client::single_cbr_test(unsigned int size,
 		        sleep_until(deadline);
                 seq++;
 		clock_gettime(CLOCK_REALTIME, &end);
-                if (duration &&
-                		ts_diff_us(start, end)/MILLION >= (long)duration)
+                if (duration && ts_diff_ms(&start, &end) >= (long)duration)
                         stop = true;
                 if (!duration && count && seq >= count)
 		  stop = true;
         }
         clock_gettime(CLOCK_REALTIME, &end);
 
-        unsigned int us = ts_diff_us(start, end);
-        LOG_INFO("sent statistics: %llu SDUs, %llu bytes in %u us",
+        long us = ts_diff_us(&start, &end);
+        LOG_INFO("sent statistics: %llu SDUs, %llu bytes in %ld us",
                         seq, seq * size, us);
         LOG_INFO("\t=> %.4f Mb/s",
                         static_cast<float>((seq*size * 8.0)/(us)));
@@ -180,16 +179,15 @@ void client::single_poisson_test(unsigned int size,
 		        sleep_until(next);
                 seq++;
                 clock_gettime(CLOCK_REALTIME, &end);
-                if (duration != 0 &&
-                		ts_diff_us(start, end)/MILLION >= (long)duration)
+                if (duration != 0 && ts_diff_ms(&start, &end) >= (long)duration)
                         stop = 1;
                 if (count != 0 && seq >= count)
 		        stop = 1;
         }
         clock_gettime(CLOCK_REALTIME, &end);
 
-        unsigned int us = ts_diff_us(start, end);
-        LOG_INFO("sent statistics: %llu SDUs, %llu bytes in %u us",
+        long us = ts_diff_us(&start, &end);
+        LOG_INFO("sent statistics: %llu SDUs, %llu bytes in %ld us",
                         seq, seq * size, us);
         LOG_INFO("\t=> %.4f Mb/s",
                         static_cast<float>((seq*size * 8.0)/us));

--- a/src/main.cc
+++ b/src/main.cc
@@ -216,14 +216,14 @@ int main(int argc, char * argv[])
                         if (distribution_type == "CBR" || distribution_type == "cbr")
                                 c.single_cbr_test(size,
                                                 count,
-                                                duration,
+                                                duration*1000,
                                                 rate,
                                                 busy,
                                                 port_id);
                         else if (distribution_type == "poisson")
                                 c.single_poisson_test( size,
                                                        count,
-                                                       duration,
+                                                       duration*1000,
                                                        rate,
                                                        busy,
                                                        poisson_mean,

--- a/src/server.cc
+++ b/src/server.cc
@@ -141,10 +141,10 @@ void server::handle_flow(int port_id)
                         sdus++;
                         if (!timed_test && sdus >= count)
                                 stop = true;
-                        if (timed_test && (sdus >= count || ts_diff_us(now,end) < 0))
+                        if (timed_test && (sdus >= count || ts_diff_us(&now,&end) < 0))
                                 stop = true;
-                        if (stat_interval && (stop || ts_diff_us(now, iv_end) < 0)) {
-                                int us = ts_diff_us(iv_start, now);
+                        if (stat_interval && (stop || ts_diff_us(&now, &iv_end) < 0)) {
+                                int us = ts_diff_us(&iv_start, &now);
 				LOG_INFO("%llu SDUs (%llu bytes) in %lu us => %.4f p/s,  %.4f Mb/s",
                                          sdus-sdus_intv,
                                          bytes_read-bytes_read_intv,
@@ -158,7 +158,7 @@ void server::handle_flow(int port_id)
                         }
                 }
                 clock_gettime(CLOCK_REALTIME, &end);
-                unsigned int ms = ts_diff_ms(start, end);
+                long ms = ts_diff_ms(&start, &end);
                 /* FIXME: removed until we have non-blocking readSDU()
                    unsigned int nms = htobe32(ms);
                    unsigned long long ncount = htobe64(totalSdus);
@@ -172,7 +172,7 @@ void server::handle_flow(int port_id)
                 ipcManager->writeSDU(port_id, statistics, sizeof(statistics) + 64);
                 */
 
-                LOG_INFO("Result: %llu SDUs, %llu bytes in %lu ms", sdus, bytes_read, ms);
+                LOG_INFO("Result: %llu SDUs, %llu bytes in %ld ms", sdus, bytes_read, ms);
                 LOG_INFO("\t=> %.4f Mb/s", static_cast<float>((bytes_read * 8.0) / (ms * 1000)));
         } catch (IPCException& ex) {
 	}

--- a/src/timeutils.c
+++ b/src/timeutils.c
@@ -55,27 +55,37 @@ void ts_diff(const struct timespec * t,
 }
 
 /* subtracting fields is faster than using ts_diff */
-long ts_diff_ns(const struct timespec &start,
-                const struct timespec &end)
+/* returns LONG_MAX on null_ptr input */
+long ts_diff_ns(const struct timespec * start,
+                const struct timespec * end)
 {
-        return (end.tv_sec-start.tv_sec)*BILLION
-                + (end.tv_nsec-start.tv_nsec);
+        if (!(start && end))
+                return LONG_MAX;
+
+        return (end->tv_sec-start->tv_sec)*BILLION
+                + (end->tv_nsec-start->tv_nsec);
 }
 
 /* subtracting fields is faster than using ts_diff */
-long ts_diff_us(const struct timespec &start,
-                const struct timespec &end)
+long ts_diff_us(const struct timespec * start,
+                const struct timespec * end)
 {
-        return (end.tv_sec-start.tv_sec)*MILLION
-                + (end.tv_nsec - start.tv_nsec)/1000L;
+        if (!(start && end))
+                return LONG_MAX;
+
+        return (end->tv_sec-start->tv_sec)*MILLION
+                + (end->tv_nsec - start->tv_nsec)/1000L;
 }
 
 /* subtracting fields is faster than using ts_diff */
-long ts_diff_ms(const struct timespec &start,
-		const struct timespec &end)
+long ts_diff_ms(const struct timespec * start,
+		const struct timespec * end)
 {
-        return (end.tv_sec-start.tv_sec)*1000L
-                + (end.tv_nsec-start.tv_nsec)/MILLION;
+        if (!(start && end))
+                return LONG_MAX;
+
+        return (end->tv_sec-start->tv_sec)*1000L
+                + (end->tv_nsec-start->tv_nsec)/MILLION;
 }
 
 /* functions for timevals */
@@ -121,19 +131,25 @@ void tv_diff(const struct timeval * t,
 }
 
 /* subtracting fields is faster than using tv_diff */
-long tv_diff_us(const struct timeval &start,
-                const struct timeval &end)
+long tv_diff_us(const struct timeval * start,
+                const struct timeval * end)
 {
-        return (end.tv_sec-start.tv_sec)*MILLION
-                + (end.tv_usec-start.tv_usec);
+        if (!(start && end))
+                return LONG_MAX;
+
+        return (end->tv_sec-start->tv_sec)*MILLION
+                + (end->tv_usec-start->tv_usec);
 }
 
 /* subtracting fields is faster than using tv_diff */
-long tv_diff_ms(const struct timeval &start,
-		const struct timeval &end)
+long tv_diff_ms(const struct timeval * start,
+		const struct timeval * end)
 {
-        return (end.tv_sec-start.tv_sec)*1000L
-                + (end.tv_usec-start.tv_usec)/1000L;
+        if (!(start && end))
+                return LONG_MAX;
+
+        return (end->tv_sec-start->tv_sec)*1000L
+                + (end->tv_usec-start->tv_usec)/1000L;
 }
 
 /* FIXME: not sure about the next two functions */
@@ -141,6 +157,9 @@ long tv_diff_ms(const struct timeval &start,
 void tv_to_ts(const struct timeval * src,
               struct timespec * dst)
 {
+        if (!(src && dst))
+                return;
+
         dst->tv_sec=src->tv_sec;
         dst->tv_nsec = src->tv_usec*1000L;
 }
@@ -149,6 +168,9 @@ void tv_to_ts(const struct timeval * src,
 void ts_to_tv(const struct timespec * src,
               struct timeval * dst)
 {
+        if (!(src && dst))
+                return;
+
         dst->tv_sec=src->tv_sec;
         dst->tv_usec = src->tv_nsec/1000L;
 }

--- a/src/timeutils.h
+++ b/src/timeutils.h
@@ -13,10 +13,19 @@
 #ifndef TIME_UTILS_H
 #define TIME_UTILS_H
 
-#define MILLION 1000000L
-#define BILLION 1000000000L
+#ifndef MILLION
+  #define MILLION  1000000
+#endif
+#ifndef BILLION
+  #define BILLION  1000000000
+#endif
 
-#include <time.h>
+#include <sys/time.h>
+#include <limits.h> //for LONG_MAX
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* functions for timespecs */
 
@@ -31,16 +40,16 @@ void ts_diff(const struct timespec * t,
              struct timespec       * res);
 
 /* subtracting fields is faster than using ts_diff */
-long ts_diff_ns(const struct timespec &start,
-                const struct timespec &end);
+long ts_diff_ns(const struct timespec * start,
+                const struct timespec * end);
 
 /* subtracting fields is faster than using ts_diff */
-long ts_diff_us(const struct timespec &start,
-                const struct timespec &end);
+long ts_diff_us(const struct timespec * start,
+                const struct timespec * end);
 
 /* subtracting fields is faster than using ts_diff */
-long ts_diff_ms(const struct timespec &start,
-		const struct timespec &end);
+long ts_diff_ms(const struct timespec * start,
+		const struct timespec * end);
 
 /* functions for timevals */
 
@@ -55,12 +64,12 @@ void tv_diff(const struct timeval * t,
              struct timeval       * res);
 
 /* subtracting fields is faster than using tv_diff */
-long tv_diff_us(const struct timeval &start,
-                const struct timeval &end);
+long tv_diff_us(const struct timeval * start,
+                const struct timeval * end);
 
 /* subtracting fields is faster than using tv_diff */
-long tv_diff_ms(const struct timeval &start,
-		const struct timeval &end);
+long tv_diff_ms(const struct timeval * start,
+		const struct timeval * end);
 
 /* FIXME: not sure about the next two functions */
 /* copying a timeval into a timespec */
@@ -70,5 +79,9 @@ void tv_to_ts(const struct timeval * src,
 /* copying a timespec into a timeval (loss of resolution) */
 void ts_to_tv(const struct timespec * src,
               struct timeval * dst);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TIME_UTILS_H */


### PR DESCRIPTION
functions on timespecs refactored to use only C language constructs
resolves possible issue brought to light as collateral on PR #9 (conversion)
