### PR TITLE
Fix passing duration in ms to tv_sec in server.cc

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -82,7 +82,7 @@ void server::handle_flow(int port_id)
 {
 	/* negotiate test with client */
 	unsigned long long count;
-	unsigned int	   duration;
+	unsigned int	   duration; /* it arrives in ms */
 	unsigned int	   sdu_size;
 
 	/* FIXME: clean up this junk ---> */
@@ -126,7 +126,7 @@ void server::handle_flow(int port_id)
 
 	clock_gettime(CLOCK_REALTIME, &start);
 	if (timed_test) {
-		intv.tv_sec = duration;
+		intv.tv_sec = duration/1000; /* tv_sec expects seconds */
 		ts_add(&start, &intv, &end);
 		if (!count)
 			count=(unsigned long long) -1L;


### PR DESCRIPTION
duration is presented to the client in seconds. It internally converts it to ms and it is negotiates with the server which receives it in ms. But the duration variable is fed to a timespec struct which tv_sec value expects s not ms. So it needs to be converted back to s.
