### PR TITLE
Modified CBR deadline calculation, added CBRC option, solves #21

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -32,6 +32,12 @@ client(const std::string& apn,
 			     unsigned int rate,
 			     bool busy,
 			     int port_id);
+	void single_cbrc_test(unsigned int size,
+			     unsigned long long count,
+			     unsigned int duration, /* ms */
+			     unsigned int rate,
+			     bool busy,
+			     int port_id);
 
 	void single_poisson_test(unsigned int size,
 				 unsigned long long count,

--- a/src/main.cc
+++ b/src/main.cc
@@ -54,42 +54,48 @@ int main(int argc, char * argv[])
 		TCLAP::ValueArg<std::string> difArg(
 			"d",
 			"dif",
-			"The name of the DIF to use, empty for any DIF, default = empty (any DIF).",
+			"The name of the DIF to use, empty for any DIF, "
+			"default = empty (any DIF).",
 			false,
 			"",
 			"string");
 		TCLAP::ValueArg<std::string> serverApnArg(
 			"",
 			"server-apn",
-			"Application process name for the server, default = traffic.generator.server.",
+			"Application process name for the server, "
+			"default = traffic.generator.server.",
 			false,
 			"traffic.generator.server",
 			"string");
 		TCLAP::ValueArg<std::string> serverApiArg(
 			"",
 			"server-api",
-			"Application process instance for the server, default = 1.",
+			"Application process instance for the server, "
+			"default = 1.",
 			false,
 			"1",
 			"string");
 		TCLAP::ValueArg<std::string> clientApnArg(
 			"",
 			"client-apn",
-			"Application process name for the client, default = traffic.generator.client.",
+			"Application process name for the client, "
+			"default = traffic.generator.client.",
 			false,
 			"traffic.generator.client",
 			"string");
 		TCLAP::ValueArg<std::string> clientApiArg(
 			"",
 			"client-api",
-			"Application process instance for the client, default = 1.",
+			"Application process instance for the client, "
+			"default = 1.",
 			false,
 			"1",
 			"string");
 		TCLAP::SwitchArg registrationArg(
 			"r",
 			"register",
-			"Register the application with the DIF, default = false.",
+			"Register the application with the DIF, "
+			"default = false.",
 			false);
 		TCLAP::ValueArg<unsigned int> sizeArg(
 			"s",
@@ -101,61 +107,72 @@ int main(int argc, char * argv[])
 		TCLAP::ValueArg<unsigned long long> countArg(
 			"c",
 			"count",
-			"Number of SDUs to send, 0 = unlimited, default = unlimited.",
+			"Number of SDUs to send, 0 = unlimited, "
+			"default = unlimited.",
 			false,
 			0,
 			"unsigned integer");
 		TCLAP::ValueArg<unsigned int> durationArg(
 			"",
 			"duration",
-			"Duration of the test (seconds), 0 = unlimited, default = 60 s IF count is unlimited.",
+			"Duration of the test (seconds), 0 = unlimited, "
+			"default = 60 s IF count is unlimited.",
 			false,
 			0,
 			"unsigned integer");
 		TCLAP::ValueArg<unsigned int> rateArg(
 			"",
 			"rate",
-			"Bitrate to send the SDUs, in kb/s, 0 = no limit, default = no limit.",
+			"Bitrate to send the SDUs, in kb/s, 0 = no limit, "
+			"default = no limit.",
 			false,
 			0,
 			"unsigned integer");
 		TCLAP::ValueArg<std::string> qoscubeArg(
 			"",
 			"qoscube",
-			"Specify the qos cube to use for flow allocation, default = unreliable.",
+			"Specify the qos cube to use for flow allocation, "
+			"default = unreliable.",
 			false,
 			"unreliable",
 			"string");
 		TCLAP::ValueArg<std::string> distributionArg(
 			"",
  			"distribution",
-			"Distribution type: CBR, poisson, default = CBR.",
+			"Distribution, currently supports Constant Bitrate, "
+			"Constant Bitrate with Catchup (Warning, this is very "
+			"sensitive to clock drift) and poisson distributed "
+			"traffic: CBR, CBRC, poisson, default = CBR.",
 			false,
 			"CBR",
 			"string");
 		TCLAP::ValueArg<double> poissonMeanArg(
 			"",
 			"poissonmean",
-			"The mean value for the poisson distribution used to generate interarrival times, default is 1.0.",
+			"The mean value for the poisson distribution used to "
+			"generate interarrival times, default is 1.0.",
 			false,
 			1,
 			"double");
 		TCLAP::ValueArg<unsigned int> intervalArg(
 			"",
 			"interval",
-			"report statistics every x ms (server), default = 1000.",
+			"report statistics every x ms (server), "
+			"default = 1000.",
 			false,
 			1000,
 			"unsigned integer");
 		TCLAP::SwitchArg sleepArg(
 			"",
 			"sleep",
-			"sleep instead of busywait between sending SDUs, default = false.",
+			"sleep instead of busywait between sending SDUs, "
+			"default = false.",
 			false);
 		TCLAP::ValueArg<std::string> csvPathArg(
 			"o",
 			"output-path",
-			"Write csv files per client to the specified directory, default = no csv output.",
+			"Write csv files per client to the specified directory, "
+			"default = no csv output.",
 			false,
 			"",
 			"string");
@@ -221,22 +238,33 @@ int main(int argc, char * argv[])
 			/* FIXME: "" means any DIF, should be cleaned up */
 			if (registration)
 				c.register_ap(dif_name);
-			int port_id = c.request_flow(server_apn, server_api, qos_cube);
-			if (distribution_type == "CBR" || distribution_type == "cbr")
+			int port_id = c.request_flow(server_apn,
+						     server_api,
+						     qos_cube);
+			if (distribution_type == "CBR" ||
+			    distribution_type == "cbr")
 				c.single_cbr_test(size,
 						  count,
 						  duration*1000,
 						  rate,
 						  busy,
 						  port_id);
-			else if (distribution_type == "poisson")
-				c.single_poisson_test( size,
-						       count,
-						       duration*1000,
-						       rate,
-						       busy,
-						       poisson_mean,
-						       port_id);
+			if (distribution_type == "CBRC" ||
+			    distribution_type == "cbrc")
+				c.single_cbrc_test(size,
+						   count,
+						   duration*1000,
+						   rate,
+						   busy,
+						   port_id);
+			if (distribution_type == "poisson")
+				c.single_poisson_test(size,
+						      count,
+						      duration*1000,
+						      rate,
+						      busy,
+						      poisson_mean,
+						      port_id);
 		}
 	} catch (rina::Exception& e) {
 		LOG_ERR("%s", e.what());


### PR DESCRIPTION
Now calculates the next interval deadline based on the finishing time
of the previous interval. This is less accurate, and will not have
the 'catchup' behaviour in case of slowdowns. However, it is less
prone to issues with the system clock, which happens a lot on Xen VM's

The previous behaviour is still available as CBRC, (CBR with catchup).
