### PR TITLE
align to the POSIX API: use write/read syscalls directly

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -63,7 +63,7 @@ int client::negotiate_test(long long count, int duration,
                 return -1;
         }
 	LOG_INFO("starting test");
-	return 0; //ALL IS GOOD
+	return 0; //ALL IS WELL
 }
 
 /* needs common code extracted and function ptrs to

--- a/src/client.h
+++ b/src/client.h
@@ -31,13 +31,13 @@ client(const std::string& apn,
 			     unsigned int duration, /* ms */
 			     unsigned int rate,
 			     bool busy,
-			     int port_id);
+			     int fd);
 	void single_cbrc_test(unsigned int size,
 			     unsigned long long count,
 			     unsigned int duration, /* ms */
 			     unsigned int rate,
 			     bool busy,
-			     int port_id);
+			     int fd);
 
 	void single_poisson_test(unsigned int size,
 				 unsigned long long count,
@@ -45,18 +45,18 @@ client(const std::string& apn,
 				 unsigned int rate,
 				 bool busy,
 				 double poisson_mean,
-				 int port_id);
+				 int fd);
 
 protected:
 
-	int negotiate_test(int port_id);
+	int negotiate_test(int fd);
 
-	void cbr_flow(int port_id);
-	void poisson_flow(int port_id);
+	void cbr_flow(int fd);
+	void poisson_flow(int fd);
 
-	void receiveServerStats(int port_id);
+	void receiveServerStats(int fd);
 private:
-	int negotiate_test (long long count, int duration, int sdu_size, int port_id);
+	int negotiate_test (long long count, int duration, int sdu_size, int fd);
 	void busy_wait_until (const struct timespec &deadline);
 	void sleep_until(const struct timespec &deadline);
 };

--- a/src/main.cc
+++ b/src/main.cc
@@ -238,9 +238,9 @@ int main(int argc, char * argv[])
 			/* FIXME: "" means any DIF, should be cleaned up */
 			if (registration)
 				c.register_ap(dif_name);
-			int port_id = c.request_flow(server_apn,
-						     server_api,
-						     qos_cube);
+			int fd = c.request_flow(server_apn,
+						server_api,
+						qos_cube);
 			if (distribution_type == "CBR" ||
 			    distribution_type == "cbr")
 				c.single_cbr_test(size,
@@ -248,7 +248,7 @@ int main(int argc, char * argv[])
 						  duration*1000,
 						  rate,
 						  busy,
-						  port_id);
+						  fd);
 			if (distribution_type == "CBRC" ||
 			    distribution_type == "cbrc")
 				c.single_cbrc_test(size,
@@ -256,7 +256,7 @@ int main(int argc, char * argv[])
 						   duration*1000,
 						   rate,
 						   busy,
-						   port_id);
+						   fd);
 			if (distribution_type == "poisson")
 				c.single_poisson_test(size,
 						      count,
@@ -264,7 +264,7 @@ int main(int argc, char * argv[])
 						      rate,
 						      busy,
 						      poisson_mean,
-						      port_id);
+						      fd);
 		}
 	} catch (rina::Exception& e) {
 		LOG_ERR("%s", e.what());

--- a/src/server.h
+++ b/src/server.h
@@ -50,7 +50,7 @@ private:
 /* internal functions */
 
 	/* respond to a new flow */
-	void handle_flow(int port_id);
+	void handle_flow(int port_id, int fd);
 };
 
 #endif

--- a/src/simple_ap.cc
+++ b/src/simple_ap.cc
@@ -143,7 +143,7 @@ int simple_ap::request_flow(const std::string& apn,
 		return 0;
 	} else
 		LOG_DBG("Port id = %d", flow.portId);
-	return flow.portId;
+	return flow.fd;
 }
 
 /* FIXME: resolution of qos_cube to flowspec should be a function */


### PR DESCRIPTION
These modifications are needed to align to the new librina API, where a true file descriptor is allocated for the I/O, so that the application can use read/write directly.

This should be merged after the corresponding pull request on IRATI/stack